### PR TITLE
Fix numpy array beta vectors

### DIFF
--- a/meep_adjoint/optimization_problem.py
+++ b/meep_adjoint/optimization_problem.py
@@ -217,7 +217,7 @@ class OptimizationProblem(object):
             If need_value or need_gradient is False, then fq or gradf in the return
             tuple will be None.
         """
-        if beta_vector or design:
+        if (beta_vector is not None) or design:
             self.update_design(beta_vector=beta_vector, design=design)
 
         #######################################################################


### PR DESCRIPTION
Fixes an issue when the user manually passes `beta_vector` as an array into the `OptimizationProblem`'s call function, rather than `None`. Previously, python threw an error complaining it can't check if a numpy array is a boolean `True`.